### PR TITLE
Add example of didState.action="signPayload"

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,6 +481,32 @@ to be signed, as well as additional information such as a key identifier or the 
 <p>TODO: Need to specify in more detail how a DID Registrar requests signing, and how the client responds.</p>
 <p>TODO: Mention how this could relate to other specs such as Universal Wallet or WebKMS.</p>
 <p>Example:</p>
+<p>{
+“jobId”: “1234”,
+“didState”: {
+“state”: “action”,
+“action”: “signPayload”,
+“signingRequest”: {
+“signingRequest1”: {
+“payload”: {
+…
+},
+“serializedPayload”: “&lt;-multibase-&gt;”,
+“kid”: null,
+“alg”: “EdDsa”,
+“verificationMethod”: “…” // could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.
+“proofPurpose”: “…” // describes the purpose of the requested signature/proof
+},
+“signingRequest2”: {
+“payload”: “8784566”,
+“kid”: null,
+“alg”: “ES256K”
+}
+}
+},
+“didRegistrationMetadata”: {},
+“didDocumentMetadata”: {}
+}</p>
 <h3 id="didstatestatewait"><a class="toc-anchor" href="#didstatestatewait" >§</a> <code>didState.state=&quot;wait&quot;</code></h3>
 <p>This state indicates that the client needs to wait, before the DID operation can be continued.</p>
 <p>Possible uses for <code>didState.state=&quot;wait&quot;</code>:</p>

--- a/index.html
+++ b/index.html
@@ -481,32 +481,33 @@ to be signed, as well as additional information such as a key identifier or the 
 <p>TODO: Need to specify in more detail how a DID Registrar requests signing, and how the client responds.</p>
 <p>TODO: Mention how this could relate to other specs such as Universal Wallet or WebKMS.</p>
 <p>Example:</p>
-<p>{
-“jobId”: “1234”,
-“didState”: {
-“state”: “action”,
-“action”: “signPayload”,
-“signingRequest”: {
-“signingRequest1”: {
-“payload”: {
-…
-},
-“serializedPayload”: “&lt;-multibase-&gt;”,
-“kid”: null,
-“alg”: “EdDsa”,
-“verificationMethod”: “…” // could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.
-“proofPurpose”: “…” // describes the purpose of the requested signature/proof
-},
-“signingRequest2”: {
-“payload”: “8784566”,
-“kid”: null,
-“alg”: “ES256K”
-}
-}
-},
-“didRegistrationMetadata”: {},
-“didDocumentMetadata”: {}
-}</p>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span>
+	<span class="token property">"jobId"</span><span class="token operator">:</span> <span class="token string">"1234"</span><span class="token punctuation">,</span>
+	<span class="token property">"didState"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+		<span class="token property">"state"</span><span class="token operator">:</span> <span class="token string">"action"</span><span class="token punctuation">,</span>
+		<span class="token property">"action"</span><span class="token operator">:</span> <span class="token string">"signPayload"</span><span class="token punctuation">,</span>
+		<span class="token property">"signingRequest"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+			<span class="token property">"signingRequest1"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+				<span class="token property">"payload"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+					...
+				<span class="token punctuation">}</span><span class="token punctuation">,</span>
+				<span class="token property">"serializedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-multibase->"</span><span class="token punctuation">,</span>
+				<span class="token property">"kid"</span><span class="token operator">:</span> <span class="token null keyword">null</span><span class="token punctuation">,</span>
+				<span class="token property">"alg"</span><span class="token operator">:</span> <span class="token string">"EdDsa"</span><span class="token punctuation">,</span>
+				<span class="token property">"verificationMethod"</span><span class="token operator">:</span> <span class="token string">"..."</span> <span class="token comment">// could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.</span>
+				<span class="token property">"proofPurpose"</span><span class="token operator">:</span> <span class="token string">".."</span> <span class="token comment">// describes the purpose of the requested signature/proof</span>
+			<span class="token punctuation">}</span><span class="token punctuation">,</span>
+			<span class="token property">"signingRequest2"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+				<span class="token property">"payload"</span><span class="token operator">:</span> <span class="token string">"8784566"</span><span class="token punctuation">,</span>
+				<span class="token property">"kid"</span><span class="token operator">:</span> <span class="token null keyword">null</span><span class="token punctuation">,</span>
+				<span class="token property">"alg"</span><span class="token operator">:</span> <span class="token string">"ES256K"</span>
+			<span class="token punctuation">}</span>
+		<span class="token punctuation">}</span>
+	<span class="token punctuation">}</span><span class="token punctuation">,</span>
+	<span class="token property">"didRegistrationMetadata"</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">,</span>
+	<span class="token property">"didDocumentMetadata"</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+<span class="token punctuation">}</span>
+</code></pre>
 <h3 id="didstatestatewait"><a class="toc-anchor" href="#didstatestatewait" >§</a> <code>didState.state=&quot;wait&quot;</code></h3>
 <p>This state indicates that the client needs to wait, before the DID operation can be continued.</p>
 <p>Possible uses for <code>didState.state=&quot;wait&quot;</code>:</p>

--- a/index.html
+++ b/index.html
@@ -498,7 +498,7 @@ to be signed, as well as additional information such as a key identifier or the 
 				<span class="token property">"proofPurpose"</span><span class="token operator">:</span> <span class="token string">".."</span> <span class="token comment">// describes the purpose of the requested signature/proof</span>
 			<span class="token punctuation">}</span><span class="token punctuation">,</span>
 			<span class="token property">"signingRequest2"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-				<span class="token property">"payload"</span><span class="token operator">:</span> <span class="token string">"8784566"</span><span class="token punctuation">,</span>
+				<span class="token property">"serializedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-multibase->"</span><span class="token punctuation">,</span>
 				<span class="token property">"kid"</span><span class="token operator">:</span> <span class="token null keyword">null</span><span class="token punctuation">,</span>
 				<span class="token property">"alg"</span><span class="token operator">:</span> <span class="token string">"ES256K"</span>
 			<span class="token punctuation">}</span>

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -540,6 +540,33 @@ TODO: Mention how this could relate to other specs such as Universal Wallet or W
 
 Example:
 
+{
+	"jobId": "1234",
+	"didState": {
+		"state": "action",
+		"action": "signPayload",
+		"signingRequest": {
+			"signingRequest1": {
+				"payload": {
+					...
+				},
+				"serializedPayload": "<-multibase->",
+				"kid": null,
+				"alg": "EdDsa",
+				"verificationMethod": "..." // could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.
+				"proofPurpose": ".." // describes the purpose of the requested signature/proof
+			},
+			"signingRequest2": {
+				"payload": "8784566",
+				"kid": null,
+				"alg": "ES256K"
+			}
+		}
+	},
+	"didRegistrationMetadata": {},
+	"didDocumentMetadata": {}
+}
+
 ### `didState.state="wait"`
 
 This state indicates that the client needs to wait, before the DID operation can be continued.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -558,7 +558,7 @@ Example:
 				"proofPurpose": ".." // describes the purpose of the requested signature/proof
 			},
 			"signingRequest2": {
-				"payload": "8784566",
+				"serializedPayload": "<-multibase->",
 				"kid": null,
 				"alg": "ES256K"
 			}

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -540,6 +540,7 @@ TODO: Mention how this could relate to other specs such as Universal Wallet or W
 
 Example:
 
+```json
 {
 	"jobId": "1234",
 	"didState": {
@@ -566,6 +567,7 @@ Example:
 	"didRegistrationMetadata": {},
 	"didDocumentMetadata": {}
 }
+```
 
 ### `didState.state="wait"`
 


### PR DESCRIPTION
This adds an example of [didState.action="signPayload"](https://identity.foundation/did-registration/#didstateactionsignpayload), with one or more signing requests, used in [Client-managed Secret Mode](https://identity.foundation/did-registration/#client-managed-secret-mode).

Addresses https://github.com/decentralized-identity/did-registration/issues/3.