### PR TITLE
Use base64 encoding instead of multibase for signing/decryption payloads.

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,14 +493,14 @@ to be signed, as well as additional information such as a key identifier or the 
 				<span class="token property">"payload"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
 					...
 				<span class="token punctuation">}</span><span class="token punctuation">,</span>
-				<span class="token property">"serializedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-multibase->"</span><span class="token punctuation">,</span>
+				<span class="token property">"serializedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-base64->"</span><span class="token punctuation">,</span>
 				<span class="token property">"kid"</span><span class="token operator">:</span> <span class="token null keyword">null</span><span class="token punctuation">,</span>
 				<span class="token property">"alg"</span><span class="token operator">:</span> <span class="token string">"EdDsa"</span><span class="token punctuation">,</span>
 				<span class="token property">"verificationMethod"</span><span class="token operator">:</span> <span class="token string">"..."</span> <span class="token comment">// could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.</span>
 				<span class="token property">"proofPurpose"</span><span class="token operator">:</span> <span class="token string">".."</span> <span class="token comment">// describes the purpose of the requested signature/proof</span>
 			<span class="token punctuation">}</span><span class="token punctuation">,</span>
 			<span class="token property">"signingRequest2"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-				<span class="token property">"serializedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-multibase->"</span><span class="token punctuation">,</span>
+				<span class="token property">"serializedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-base64->"</span><span class="token punctuation">,</span>
 				<span class="token property">"kid"</span><span class="token operator">:</span> <span class="token null keyword">null</span><span class="token punctuation">,</span>
 				<span class="token property">"alg"</span><span class="token operator">:</span> <span class="token string">"ES256K"</span>
 			<span class="token punctuation">}</span>
@@ -527,13 +527,13 @@ to be decrypted, as well as additional information such as a key identifier or t
 		<span class="token property">"action"</span><span class="token operator">:</span> <span class="token string">"decryptPayload"</span><span class="token punctuation">,</span>
 		<span class="token property">"decryptionRequest"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
 			<span class="token property">"decryptionRequest1"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-				<span class="token property">"encryptedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-multibase->"</span><span class="token punctuation">,</span>
+				<span class="token property">"encryptedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-base64->"</span><span class="token punctuation">,</span>
 				<span class="token property">"kid"</span><span class="token operator">:</span> <span class="token null keyword">null</span><span class="token punctuation">,</span>
 				<span class="token property">"enc"</span><span class="token operator">:</span> <span class="token string">"A128GCM"</span><span class="token punctuation">,</span>
 				<span class="token property">"verificationMethod"</span><span class="token operator">:</span> <span class="token string">"..."</span> <span class="token comment">// could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.</span>
 			<span class="token punctuation">}</span><span class="token punctuation">,</span>
 			<span class="token property">"decryptionRequest2"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-				<span class="token property">"encryptedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-multibase->"</span><span class="token punctuation">,</span>
+				<span class="token property">"encryptedPayload"</span><span class="token operator">:</span> <span class="token string">"&lt;-base64->"</span><span class="token punctuation">,</span>
 				<span class="token property">"kid"</span><span class="token operator">:</span> <span class="token null keyword">null</span><span class="token punctuation">,</span>
 				<span class="token property">"enc"</span><span class="token operator">:</span> <span class="token string">"A256GCM"</span>
 			<span class="token punctuation">}</span>

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -562,14 +562,14 @@ Example:
 				"payload": {
 					...
 				},
-				"serializedPayload": "<-multibase->",
+				"serializedPayload": "<-base64->",
 				"kid": null,
 				"alg": "EdDsa",
 				"verificationMethod": "..." // could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.
 				"proofPurpose": ".." // describes the purpose of the requested signature/proof
 			},
 			"signingRequest2": {
-				"serializedPayload": "<-multibase->",
+				"serializedPayload": "<-base64->",
 				"kid": null,
 				"alg": "ES256K"
 			}
@@ -606,13 +606,13 @@ Example:
 		"action": "decryptPayload",
 		"decryptionRequest": {
 			"decryptionRequest1": {
-				"encryptedPayload": "<-multibase->",
+				"encryptedPayload": "<-base64->",
 				"kid": null,
 				"enc": "A128GCM",
 				"verificationMethod": "..." // could point to a verificationMethod, incl. VerifiableConditions with threshold, etc.
 			},
 			"decryptionRequest2": {
-				"encryptedPayload": "<-multibase->",
+				"encryptedPayload": "<-base64->",
 				"kid": null,
 				"enc": "A256GCM"
 			}


### PR DESCRIPTION
For a pure JSON data format, it might be better to use Base64 encoding instead of more complex Multibase.